### PR TITLE
Fix an offense for `Layout/EmptyLinesAfterModuleInclusion`

### DIFF
--- a/lib/rubocop/cop/rspec/extra/restrict_block_tag_value.rb
+++ b/lib/rubocop/cop/rspec/extra/restrict_block_tag_value.rb
@@ -17,6 +17,7 @@ module RuboCop
         #
         class RestrictBlockTagValue < Base
           include Metadata
+
           MSG = "This value is not allowed in this tag. Allowed tag value: %<allow_tag_value>s."
 
           def on_metadata(_symbols, hash)


### PR DESCRIPTION
```
❯ bundle exec rubocop -A
Inspecting 18 files
......C...........

Offenses:

lib/rubocop/cop/rspec/extra/restrict_block_tag_value.rb:19:11: C: [Corrected] Layout/EmptyLinesAfterModuleInclusion: Add an empty line after module inclusion.
          include Metadata
          ^^^^^^^^^^^^^^^^

18 files inspected, 1 offense detected, 1 offense corrected
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
